### PR TITLE
Adds more flexible attribute selection to user(name).get()

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -234,6 +234,10 @@ module.exports = {
         includeMembership: ['all'],
         includeDeleted: false
       };
+      if( opts ) {
+        if( opts.fields && opts.fields.length ) params.attributes = ['*']
+        if( opts.attributes && opts.attributes.length ) params.attributes = opts.attributes
+      }
       this.ad.find(params, (err, results) => {
         if (err) {
           /* istanbul ignore next */

--- a/src/user.js
+++ b/src/user.js
@@ -234,9 +234,15 @@ module.exports = {
         includeMembership: ['all'],
         includeDeleted: false
       };
-      if( opts ) {
-        if( opts.fields && opts.fields.length ) params.attributes = ['*']
-        if( opts.attributes && opts.attributes.length ) params.attributes = opts.attributes
+      if (opts) {
+        if (opts.fields && opts.fields.length) {
+          if (opts.fields === 'all' || opts.fields.includes('all')) {
+            params.attributes = ['*'];
+            delete opts.fields;
+          } else {
+            params.attributes = ['dn'].concat(opts.fields);
+          }
+        }
       }
       this.ad.find(params, (err, results) => {
         if (err) {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -135,17 +135,23 @@ test('user(user).get(opts) should take filter options', async () => {
   expect(results.givenName).not.toBeUndefined();
 });
 
-test('user(user).get({filter: []}) should take filter option for all attributes', async () => {
-  let results = await ad.user('test51').get({
-    fields: 'all'
-  });
+test('user(user).get(opts) should take filter option for all attributes', async () => {
+  let results = await ad
+    .cache(false)
+    .user('test51')
+    .get({
+      fields: 'all'
+    });
   expect(results.whenCreated).toBeDefined();
 });
 
-test('user(user).get({filter: []}) should take filter option for attributes not in the default attribute set', async () => {
-  let results = await ad.user('test51').get({
-    fields: ['whenCreated']
-  });
+test('user(user).get(opts) should take filter option for attributes not in the default attribute set', async () => {
+  let results = await ad
+    .cache(false)
+    .user('test51')
+    .get({
+      fields: ['whenCreated']
+    });
   expect(results.whenCreated).toBeDefined();
 });
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -135,6 +135,20 @@ test('user(user).get(opts) should take filter options', async () => {
   expect(results.givenName).not.toBeUndefined();
 });
 
+test('user(user).get({filter: []}) should take filter option for all attributes', async () => {
+  let results = await ad.user('test51').get({
+    fields: 'all'
+  });
+  expect(results.whenCreated).toBeDefined();
+});
+
+test('user(user).get({filter: []}) should take filter option for attributes not in the default attribute set', async () => {
+  let results = await ad.user('test51').get({
+    fields: ['whenCreated']
+  });
+  expect(results.whenCreated).toBeDefined();
+});
+
 test('user(user).exists() should return true for a given user', async () => {
   expect(await ad.user('test51').exists()).toBe(true);
 });


### PR DESCRIPTION
Addresses #11 

Another thought I just had, related to disabling the cache in the tests - should probably skip the cache if a requested field doesn't exist in the cache.